### PR TITLE
Split GraphQL queries into v1 and v2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "common-api",
+  "name": "common-api-ts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -22,6 +22,7 @@
         "@types/node": "^20.11.25",
         "@types/ws": "^8.5.10",
         "prettier": "3.2.5",
+        "trace-unhandled": "^2.0.1",
         "ts-node": "^10.9.2",
         "type": "^2.7.2",
         "typescript": "~5.2.0"
@@ -270,6 +271,12 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
     "node_modules/body-parser": {
       "version": "2.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.0-beta.2.tgz",
@@ -297,6 +304,16 @@
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/bytes": {
@@ -335,6 +352,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/config": {
       "version": "3.3.11",
@@ -403,6 +426,20 @@
       "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
         "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -595,6 +632,19 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -624,6 +674,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -648,6 +704,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -744,6 +820,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/haxec": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/haxec/-/haxec-2.0.1.tgz",
+      "integrity": "sha512-2DaSqGZIzgVkZ4YFHbk9Su0Q6gm7YbzNX9njOHK/D/XklOdvgTemsPmjcyExlLdkl7lRlNIW0Wxo6niVfpWedw==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "spawn-wrap": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -770,6 +859,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -788,6 +887,21 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -797,6 +911,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-error": {
@@ -843,6 +972,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -904,6 +1045,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -918,6 +1068,15 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -993,6 +1152,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/router": {
       "version": "2.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.2.tgz",
@@ -1041,6 +1215,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/send": {
       "version": "1.0.0-beta.2",
@@ -1117,6 +1300,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -1132,6 +1336,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/statuses": {
@@ -1154,6 +1381,21 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/trace-unhandled": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trace-unhandled/-/trace-unhandled-2.0.1.tgz",
+      "integrity": "sha512-wOZbhBiNyuZTs0b/ADZFTiTDVVDsvKQj/RkVJTKefH6u9CowGDSR+H/3miaGUrYCCuzS0nVmIzpbIIm6lRF8gg==",
+      "dev": true,
+      "dependencies": {
+        "haxec": "^2.0.1"
+      },
+      "bin": {
+        "trace-unhandled": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -1283,6 +1525,27 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^20.11.25",
     "@types/ws": "^8.5.10",
     "prettier": "3.2.5",
+    "trace-unhandled": "^2.0.1",
     "ts-node": "^10.9.2",
     "type": "^2.7.2",
     "typescript": "~5.2.0"

--- a/src/grapqhl/index.ts
+++ b/src/grapqhl/index.ts
@@ -41,7 +41,6 @@ export async function readWholeConnection<T>(
         }
       }
     } catch (err) {
-      // TODO: throw error?
       console.error(err);
       break;
     }

--- a/src/grapqhl/pools.ts
+++ b/src/grapqhl/pools.ts
@@ -2,7 +2,8 @@ import { Client } from "graphql-ws";
 import { RawElement, readWholeConnection } from ".";
 import { PairSwapVolume, PoolV2 } from "../models/pool";
 import { Observable, mergeMap } from "rxjs";
-import { poolsV2ConnectionsQuery } from "./queries";
+import { poolsV2ConnectionsQuery as poolReservesV2 } from "./v2/queries";
+import { poolsV2ConnectionsQuery as poolReservesV1 } from "./v1/queries";
 
 export function poolsV2$(
   rawObservable: Observable<RawElement>,
@@ -13,7 +14,17 @@ export function poolsV2$(
 }
 
 export function loadInitPoolReserves(client: Client): Promise<PoolV2[]> {
-  return readWholeConnection<PoolV2>(client, poolsV2ConnectionsQuery);
+  const v1 = loadInitReservesV1(client);
+  const v2 = loadInitReservesV2(client);
+  return Promise.all([v1, v2]).then((values) => values.flat());
+}
+
+export function loadInitReservesV1(client: Client): Promise<PoolV2[]> {
+  return readWholeConnection<PoolV2>(client, poolReservesV1);
+}
+
+export function loadInitReservesV2(client: Client): Promise<PoolV2[]> {
+  return readWholeConnection<PoolV2>(client, poolReservesV2);
 }
 
 /// Query all pair swap volumes from the GraphQL server.

--- a/src/grapqhl/psp22.ts
+++ b/src/grapqhl/psp22.ts
@@ -1,5 +1,5 @@
 import { RawElement, readWholeConnection } from ".";
-import { psp22TokenBalancesConnectionsQuery } from "./queries";
+import { psp22TokenBalancesConnectionsQuery } from "./v2/queries";
 import { TokenBalances, TokenBalance } from "../models/psp22";
 import { Observable, map, reduce } from "rxjs";
 import { Client } from "graphql-ws";

--- a/src/grapqhl/v1/queries.ts
+++ b/src/grapqhl/v1/queries.ts
@@ -1,16 +1,16 @@
-import { ConnectionQuery } from "./connection";
-import { SubscriptionQuery } from "./subscription";
+import { ConnectionQuery } from "../connection";
+import { SubscriptionQuery } from "../subscription";
 
 export const psp22TokenBalancesConnectionsQuery: ConnectionQuery =
   new ConnectionQuery(
     "psp22TokenBalances",
-    "account amount token blockHeight blockTimestamp id",
+    "account amount token lastUpdateBlockHeight lastUpdateTimestamp id",
   );
 
 export const pspTokenBalancesSubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "psp22TokenBalances",
-    "account amount token blockHeight blockTimestamp",
+    "account amount token lastUpdateBlockHeight lastUpdateTimestamp",
   );
 
 export const nativeTransfersSubscriptionQuery: SubscriptionQuery =
@@ -24,12 +24,12 @@ export const nativeTransfersSubscriptionQuery: SubscriptionQuery =
 export const poolsV2SubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "pools",
-    "id token0 token1 reserves0 reserves1 blockTimestamp",
+    "id token0 token1 reserves0 reserves1 lastUpdateTimestamp",
     50,
-    "blockTimestamp_ASC",
+    "lastUpdateTimestamp_ASC",
   );
 
 export const poolsV2ConnectionsQuery: ConnectionQuery = new ConnectionQuery(
   "pools",
-  "id token0 token1 reserves0 reserves1 blockTimestamp",
+  "id token0 token1 reserves0 reserves1 lastUpdateTimestamp",
 );

--- a/src/grapqhl/v2/queries.ts
+++ b/src/grapqhl/v2/queries.ts
@@ -1,0 +1,35 @@
+import { ConnectionQuery } from "../connection";
+import { SubscriptionQuery } from "../subscription";
+
+export const psp22TokenBalancesConnectionsQuery: ConnectionQuery =
+  new ConnectionQuery(
+    "psp22TokenBalances",
+    "account amount token blockHeight blockTimestamp id",
+  );
+
+export const pspTokenBalancesSubscriptionQuery: SubscriptionQuery =
+  new SubscriptionQuery(
+    "psp22TokenBalances",
+    "account amount token blockHeight blockTimestamp",
+  );
+
+export const nativeTransfersSubscriptionQuery: SubscriptionQuery =
+  new SubscriptionQuery(
+    "nativeTransfers",
+    "extrinsicHash sender recipient amount blockNumber timestamp",
+    50,
+    "timestamp_ASC",
+  );
+
+export const poolsV2SubscriptionQuery: SubscriptionQuery =
+  new SubscriptionQuery(
+    "pools",
+    "id token0 token1 reserves0 reserves1 blockTimestamp",
+    50,
+    "blockTimestamp_ASC",
+  );
+
+export const poolsV2ConnectionsQuery: ConnectionQuery = new ConnectionQuery(
+  "pools",
+  "id token0 token1 reserves0 reserves1 blockTimestamp",
+);

--- a/src/servers/ws/amm.ts
+++ b/src/servers/ws/amm.ts
@@ -13,13 +13,13 @@ export function setupPoolsV2OverWs(
         console.log("error sending known state", error);
       }
     });
+
     const subscription = pools.subscribe((pool) => {
-      ws.send(JSON.stringify(pool), function () {
-        //
-        // Ignore errors.
-        //
+      ws.send(JSON.stringify(pool), function (err) {
+        console.error(`Error when sending data to the client over WS: ${err}`);
       });
     });
+
     console.log("started feeding new client the pools events");
 
     ws.on("error", console.error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,21 @@ export function runProgram(
     onerror(e);
   }
 }
+
+export function isV2GraphQLReservesError(err: any): boolean {
+  let v2QueryErrors = new Set([
+    `Value "blockTimestamp_ASC" does not exist in "PoolOrderByInput" enum.`,
+    `Cannot query field "blockTimestamp" on type "Pool".`,
+  ]);
+  let errMsgs = Array.isArray(err) ? err : [err];
+  return errMsgs.every((errMsg) => v2QueryErrors.has(errMsg.message));
+}
+
+export function isV1GraphQLReservesError(err: any): boolean {
+  let v1QueryErrors = new Set([
+    `Cannot query field "lastUpdateTimestamp" on type "Pool".`,
+    `Value "lastUpdateTimestamp_ASC" does not exist in "PoolOrderByInput" enum. Did you mean the enum value "blockTimestamp_ASC"?`,
+  ]);
+  let errMsgs = Array.isArray(err) ? err : [err];
+  return errMsgs.every((errMsg) => v1QueryErrors.has(errMsg.message));
+}


### PR DESCRIPTION
There's an update to Indexer (DB and GraphQL) coming that will change the tables - which will also change the GraphQL API. Since common-api is dependant on it, we need to update its queries as well but that would mean it's broken for a moment where there's a switch happening. 

This PR adapts the code so that it can work with both pre-* and post-* migration changes. Hopefully.

The `v1`-handling code can be removed after migration.