### PR TITLE
A0-2999: Update all workflows to run on node20

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: GIT | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: DOCKER | Build and push
         uses: ./.github/actions/build-and-push


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.