### PR TITLE
Fix column names after graphql redeployment

### DIFF
--- a/src/grapqhl/subscription.ts
+++ b/src/grapqhl/subscription.ts
@@ -8,7 +8,7 @@ export class SubscriptionQuery {
     nodeKey: string,
     nodeDesc: string,
     limit: number = 50,
-    orderBy: string = "lastUpdateTimestamp_ASC",
+    orderBy: string = "blockTimestamp_ASC",
   ) {
     this.orderBy = orderBy;
     this.limit = limit;

--- a/src/grapqhl/v2/queries.ts
+++ b/src/grapqhl/v2/queries.ts
@@ -4,13 +4,13 @@ import { SubscriptionQuery } from "../subscription";
 export const psp22TokenBalancesConnectionsQuery: ConnectionQuery =
   new ConnectionQuery(
     "psp22TokenBalances",
-    "account amount token lastUpdateBlockHeight lastUpdateTimestamp id",
+    "account amount token blockHeight blockTimestamp id",
   );
 
 export const pspTokenBalancesSubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "psp22TokenBalances",
-    "account amount token lastUpdateBlockHeight lastUpdateTimestamp",
+    "account amount token blockHeight blockTimestamp",
   );
 
 export const nativeTransfersSubscriptionQuery: SubscriptionQuery =
@@ -24,12 +24,12 @@ export const nativeTransfersSubscriptionQuery: SubscriptionQuery =
 export const poolsV2SubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "pools",
-    "id token0 token1 reserves0 reserves1 lastUpdateTimestamp",
+    "id token0 token1 reserves0 reserves1 blockTimestamp",
     50,
-    "lastUpdateTimestamp_ASC",
+    "blockTimestamp_ASC",
   );
 
 export const poolsV2ConnectionsQuery: ConnectionQuery = new ConnectionQuery(
   "pools",
-  "id token0 token1 reserves0 reserves1 lastUpdateTimestamp",
+  "id token0 token1 reserves0 reserves1 blockTimestamp",
 );


### PR DESCRIPTION
Should be fine now since we handle both v1 and v2.