### PR TITLE
CMN-618: Fix failing updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "common-api-ts",
+  "name": "common-api",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "common-api",
+  "name": "common-api-ts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/grapqhl/pools.ts
+++ b/src/grapqhl/pools.ts
@@ -13,12 +13,6 @@ export function poolsV2$(
   );
 }
 
-export function loadInitPoolReserves(client: Client): Promise<PoolV2[]> {
-  const v1 = loadInitReservesV1(client);
-  const v2 = loadInitReservesV2(client);
-  return Promise.all([v1, v2]).then((values) => values.flat());
-}
-
 export function loadInitReservesV1(client: Client): Promise<PoolV2[]> {
   return readWholeConnection<PoolV2>(client, poolReservesV1);
 }

--- a/src/grapqhl/v1/queries.ts
+++ b/src/grapqhl/v1/queries.ts
@@ -17,7 +17,7 @@ export const nativeTransfersSubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "nativeTransfers",
     "extrinsicHash sender recipient amount blockNumber timestamp",
-    50,
+    200,
     "timestamp_ASC",
   );
 
@@ -25,7 +25,7 @@ export const poolsV2SubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "pools",
     "id token0 token1 reserves0 reserves1 lastUpdateTimestamp",
-    50,
+    200,
     "lastUpdateTimestamp_ASC",
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ async function main(): Promise<void> {
       })
 
       if (useV1Subscription) {
-        console.log("Proceeding with v1 subscription query on pool updates")
+        log.info("Proceeding with v1 subscription query on pool updates")
         let poolsV2Updates$ = updatePools(graphqlClient, pools, v1PoolSubscriptionQuery)
         setupPoolsV2OverWs(wsServer, poolsV2Updates$, pools);
       }
@@ -141,7 +141,7 @@ async function main(): Promise<void> {
           pools.updateBatch(initPools)
         })
 
-        console.log("Proceeding with v2 subscription query on pool updates")
+        log.info("Proceeding with v2 subscription query on pool updates")
         let poolsV2Updates$ = updatePools(graphqlClient, pools, v2PoolSubscriptionQuery)
         setupPoolsV2OverWs(wsServer, poolsV2Updates$, pools);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,7 @@ function updatePools(graphqlClient: Client, pools: Pools, subscriptionQuery: Sub
   // Share the observable to enable multiple subscriptions (forEach and setupPoolsV2OverWs).
   let poolsV2Updates$ = poolsV2$(graphqlPoolV2$).pipe(share());
 
-  poolsV2Updates$.forEach((pool) => {
-    console.log("Updated " + pool.id)
-    pools.update(pool)
-  })
+  poolsV2Updates$.forEach((pool) => pools.update(pool))
   return poolsV2Updates$
 }
 

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -34,7 +34,7 @@ export class Pools {
   update(newPool: PoolV2) {
     // TODO remove this hack when there are no longer 2 versions of subscription query
     newPool = fixBrokenPoolV2(newPool)
-    
+
     let pool = this.pools.get(newPool.id)
     if (pool === undefined) {
       this.pools.set(newPool.id, newPool)
@@ -123,7 +123,7 @@ function fixBrokenPoolV2(pool: any): PoolV2 {
       token1: pool.token1,
       reserves0: pool.reserves0,
       reserves1: pool.reserves1,
-      lastUpdateTimestamp: pool['blockTimestamp'],
+      lastUpdateTimestamp: pool.blockTimestamp,
     }
   }
   return pool as PoolV2

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -113,7 +113,7 @@ export function poolsV2FromArray(pools: PoolV2[]): Pools {
 // it is possible. This function "fixes" the `PoolV2` by returning a proper object of type `PoolV2`
 // which doesn't contain `blockTimestamp` but contains `lastUpdateTimestamp` instead.
 function fixBrokenPoolV2(pool: any): PoolV2 {
-  if (pool.hasOwnProperty('blockTimestamp')) {
+  if (pool['blockTimestamp']) {
     return {
       id: pool.id,
       token0: pool.token0,

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -46,10 +46,7 @@ export class Pools {
   }
 
   updateBatch(pools: PoolV2[]) {
-    pools.forEach((pool) => {
-      console.log("pool: " + JSON.stringify(pool))
-      this.update(pool)
-    });
+    pools.forEach((pool) => this.update(pool));
   }
 
   async setGraphqlClient(client: Client) {

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -32,18 +32,24 @@ export class Pools {
   }
 
   update(newPool: PoolV2) {
-    let pool = this.pools.get(newPool.id);
+    // TODO remove this hack when there are no longer 2 versions of subscription query
+    newPool = fixBrokenPoolV2(newPool)
+    
+    let pool = this.pools.get(newPool.id)
     if (pool === undefined) {
-      this.pools.set(newPool.id, newPool);
-      return;
+      this.pools.set(newPool.id, newPool)
+      return
     }
     if (pool.lastUpdateTimestamp < newPool.lastUpdateTimestamp) {
-      this.pools.set(newPool.id, newPool);
+      this.pools.set(newPool.id, newPool)
     }
   }
 
   updateBatch(pools: PoolV2[]) {
-    pools.forEach((pool) => this.update(pool));
+    pools.forEach((pool) => {
+      console.log("pool: " + JSON.stringify(pool))
+      this.update(pool)
+    });
   }
 
   async setGraphqlClient(client: Client) {
@@ -102,4 +108,23 @@ export class Pools {
 
 export function poolsV2FromArray(pools: PoolV2[]): Pools {
   return Pools.fromArray(pools);
+}
+
+// While 2 versions of subscription query exist, we may get a PoolV2 value from the observer
+// which doesn't contain the `lastUpdateTimestamp` field, and contains `blockTimestamp` instead.
+// Formally, it shouldn't be typed with `PoolV2` but due to the sketchy behaviour of `Observable`
+// it is possible. This function "fixes" the `PoolV2` by returning a proper object of type `PoolV2`
+// which doesn't contain `blockTimestamp` but contains `lastUpdateTimestamp` instead.
+function fixBrokenPoolV2(pool: any): PoolV2 {
+  if (pool.hasOwnProperty('blockTimestamp')) {
+    return {
+      id: pool.id,
+      token0: pool.token0,
+      token1: pool.token1,
+      reserves0: pool.reserves0,
+      reserves1: pool.reserves1,
+      lastUpdateTimestamp: pool['blockTimestamp'],
+    }
+  }
+  return pool as PoolV2
 }


### PR DESCRIPTION
## Description

Split the updates observable so that there's a separate one for `v1` subscription query, and for a `v2` subscription query.
Having the observables for `v1` and `v2` merged resulted in failure, because, exactly one of these merged sub-observables was failing, and failure of a sub-observable caused failure of the whole top-level observable.

Exactly one of `v1, v2` should work, so we make a choice which one to use, based on the initial load of pool updates, which is done before we commit to a particular subscription.

## Testing

Tested with `testnet` and `mainnet` environments which use `v1` and `v2` subscription query versions correspondingly.

### Testnet

To connect with `testnet` indexer I used the host `indexer.dev.azero.dev`. I increased the `limit` in `poolsV2SubscriptionQuery` in `graphql/v1/queries.ts` to `200` to make sure that all the pools make an update (on testnet there's around `~100` pools).

No error was displayed which means that the initial update worked with `v1`.

I monitored the pair `5HShNrPGgi2UQ6aJ2bzeJLc7dSfeUPwtMTjdYN8z6eLZsWy3` which is `TZERO, PAPER` depending on my actions. In contracts UI I initially saw output of `getReserves`
```
[
  '23,291,230,299,139,832,854',
  '16,484,658,125,124,704',
  '1,716,551,355',
]
```
the last one being the timestamp. The initial `curl` to `common-api` returned
```
"reserves0":"23291230299139832854",
"reserves1":"16484658125124704",
"lastUpdateTimestamp":"1716551355000"
```
which matches the contracts ui output.

Then I made a small trade on `TZERO, PAP` using `test.common.fi`.

Contracts ui:

```
[
  '23,293,230,299,139,832,854',
  '16,483,246,967,619,012',
  '1,716,551,468',
]
```

curl to `common-api`:

```
"reserves0":"23293230299139832854",
"reserves1":"16483246967619012",
"lastUpdateTimestamp":"1716551468000"
```
so it works

### mainnet

Here I ran `common-api` and saw error printed:

```
[
  {
    message: 'Cannot query field "lastUpdateTimestamp" on type "Pool".',
    locations: [ [Object] ]
  }
]
```
which means that it has chosen `v2` subscription queries. I wasn't able to cause any trade, but by logging to console, I made sure that no error was thrown when using the `v2` subscription updates.