### PR TITLE
CMN-654: Fix volumes (include input and output) and scale according to decimals

### DIFF
--- a/src/grapqhl/pools.ts
+++ b/src/grapqhl/pools.ts
@@ -153,7 +153,9 @@ export async function pairSwapVolume(
     pool: poolId,
     // can't do 0n b/c it breaks in runtime with serialization error.
     amount0_in: 0 as unknown as bigint,
+    amount0_out: 0 as unknown as bigint,
     amount1_in: 0 as unknown as bigint,
+    amount1_out: 0 as unknown as bigint,
   };
   const query = client.iterate({
     query: pairSwapVolumeQuery(poolId, fromMillis, toMillis),
@@ -212,7 +214,9 @@ function pairSwapVolumesQuery(fromMillis: bigint, toMillis: bigint): string {
     pairSwapVolumes(fromMillis: ${fromMillis}, toMillis: ${toMillis}) {
       pool
       amount0_in
+      amount0_out
       amount1_in
+      amount1_out
     }
   }
 `;
@@ -228,7 +232,9 @@ function pairSwapVolumeQuery(
     pairSwapVolume(poolId: "${poolId}", fromMillis: ${fromMillis}, toMillis: ${toMillis}) {
       pool
       amount0_in
+      amount0_out
       amount1_in
+      amount1_out
     }
   }
 `;

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -25,6 +25,11 @@ export interface PairSwapVolume {
   amount1_out: bigint;
 }
 
+export interface TotalPairSwapVolume {
+  token0Volume: number,
+  token1Volume: number,
+}
+
 export interface LowestHighestSwapPrice {
   pool: string;
   min_price_0in: number | null;

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -20,7 +20,9 @@ export interface PoolV2 {
 export interface PairSwapVolume {
   pool: string;
   amount0_in: bigint;
+  amount0_out: bigint;
   amount1_in: bigint;
+  amount1_out: bigint;
 }
 
 export interface LowestHighestSwapPrice {

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -26,8 +26,8 @@ export interface PairSwapVolume {
 }
 
 export interface TotalPairSwapVolume {
-  token0Volume: number,
-  token1Volume: number,
+  token0Volume: number;
+  token1Volume: number;
 }
 
 export interface LowestHighestSwapPrice {

--- a/src/services/coingeckoIntegration.ts
+++ b/src/services/coingeckoIntegration.ts
@@ -1,4 +1,9 @@
-import { LowestHighestSwapPrice, Pools, PoolV2, TotalPairSwapVolume } from "../models/pool";
+import {
+  LowestHighestSwapPrice,
+  Pools,
+  PoolV2,
+  TotalPairSwapVolume,
+} from "../models/pool";
 import { PairSwapVolume } from "../models/pool";
 import { UsdPriceCache, NamedUsdPriceCaches } from "./coingeckoPriceCache";
 import { TokenInfoById } from "../models/tokens";
@@ -61,11 +66,15 @@ export class CoingeckoIntegration {
     return tickers;
   }
 
-  private async pairVolume(pool: PoolV2, tokenInfo: TokenInfoById): Promise<TotalPairSwapVolume> { // token0 volume, token1 volume
+  private async pairVolume(
+    pool: PoolV2,
+    tokenInfo: TokenInfoById,
+  ): Promise<TotalPairSwapVolume> {
+    // token0 volume, token1 volume
     let volume = {
       token0Volume: 0,
       token1Volume: 0,
-    }
+    };
     let now_millis = new Date().getTime();
     let yesterday_millis = now_millis - DAY_IN_MILLIS;
     const poolVolume = await this.pools.poolSwapVolume(
@@ -77,12 +86,16 @@ export class CoingeckoIntegration {
       let decimals0 = this.tokenInfo.getDecimals(pool.token0);
       let decimals1 = this.tokenInfo.getDecimals(pool.token1);
       if (decimals0 && decimals1) {
-        const vol0 = Number(poolVolume.amount0_in + poolVolume.amount0_out) / (10 ** decimals0)
-        const vol1 = Number(poolVolume.amount1_in + poolVolume.amount1_out) / (10 ** decimals1)
+        const vol0 =
+          Number(poolVolume.amount0_in + poolVolume.amount0_out) /
+          10 ** decimals0;
+        const vol1 =
+          Number(poolVolume.amount1_in + poolVolume.amount1_out) /
+          10 ** decimals1;
         volume = {
           token0Volume: vol0,
           token1Volume: vol1,
-        }
+        };
       }
     }
     return volume;


### PR DESCRIPTION
## Description

Fetch output volumes in addition to input volumes, and scale the result by appropriate decimals.

## Testing

```
[
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5C6s2qJAG5dCmPvR9WyKAVL6vJRDS9BjMwbrqwXGCsPiFViF",
    "last_price": "0.4687843606038592",
    "base_volume": "242389.58560047718",
    "target_volume": "120043.456584",
    "liquidity_in_usd": "1539668.3691755722",
    "high": "0.5348470066630467",
    "low": "0.47504991147809117"
  },
  {
    "ticker_id": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5CiP96MhEGHnLFGS64uVznrwbuVdFj6kewrEZoLRzxUEqxws",
    "last_price": "1.0085995504748813",
    "base_volume": "7491.224977",
    "target_volume": "7577.298633",
    "liquidity_in_usd": "1013085.651204156",
    "high": "1.0185838995465697",
    "low": "0.9984141975715982"
  },
  {
    "ticker_id": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5D4DxNZMLG4Cff9G7rywJR2HPwu3D9zgeKHwLFh1xNjTBQ1K",
    "last_price": "2873.5000574879687",
    "base_volume": "0.002372873656222569",
    "target_volume": "7.17842",
    "liquidity_in_usd": "166.97434913227107",
    "high": "3195.616185094347",
    "low": "2968.0475900162387"
  },
  {
    "ticker_id": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5DJkepNcfcm1S1KNDELMUNJDGQ1wgDuHY5457ac3kbmjGakA",
    "last_price": "1.2988209458822642",
    "base_volume": "0",
    "target_volume": "0",
    "liquidity_in_usd": "1.997924151905",
    "high": null,
    "low": null
  },
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "pool_id": "5DVQsLtAEKgwpd1k1dkcKbuQ4UBkYUTKW2dTMVXXNywUsFcZ",
    "last_price": "0.46600450255730913",
    "base_volume": "24.250456162899",
    "target_volume": "12.130154",
    "liquidity_in_usd": "245.9665514754435",
    "high": "0.5408518928217904",
    "low": "0.4773836765213604"
  },
  {
    "ticker_id": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u_5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "base_currency": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "target_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "pool_id": "5Gr7hs43AZdG5MygDG6LU9ADcw5QtgpULELrZQHKi8sDHNgs",
    "last_price": "2908.022760260988",
    "base_volume": "0.001490428540692986",
    "target_volume": "4.636103",
    "liquidity_in_usd": "107.82266750238836",
    "high": "3284.5872379385582",
    "low": "2908.022760260988"
  },
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "pool_id": "5HaM6dHg3ymuQ6NSCquMkzBLLHv9t1H4YvBDMarox37PbusE",
    "last_price": "0.00016407728063118539",
    "base_volume": "4780.86697914112",
    "target_volume": "0.7864125311456559",
    "liquidity_in_usd": "901461.7108819829",
    "high": "0.0001650268538349057",
    "low": "0.00016373395706176762"
  },
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5EEtCdKLyyhQnNQWWWPM1fMDx1WdVuiaoR9cA6CWttgyxtuJ",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5EEtCdKLyyhQnNQWWWPM1fMDx1WdVuiaoR9cA6CWttgyxtuJ",
    "pool_id": "5HNe42pTtcpGYsE3hPy6NKuV8mmKcN7Tz9SBUsSgxTDrWQmh",
    "last_price": "0.00000729",
    "base_volume": "0",
    "target_volume": "0",
    "liquidity_in_usd": "0.00056113038211428",
    "high": null,
    "low": null
  }
]
```