### PR TITLE
CMN-654: Fix low high

### DIFF
--- a/src/grapqhl/pools.ts
+++ b/src/grapqhl/pools.ts
@@ -87,25 +87,16 @@ export async function pairLowestHighestSwapPrice(
       if (swapPrices.length > 2 || swapPrices.length == 0) {
         console.error(`Expected 1 or 2 swap prices, got ${swapPrices.length}`);
       } else {
-        let minPrice0In = swapPrices[0].min_price_0in
-        if (minPrice0In === null && swapPrices[1]) {
-          minPrice0In = swapPrices[1].min_price_0in
-        }
-
-        let maxPrice0In = swapPrices[0].max_price_0in
-        if (maxPrice0In === null && swapPrices[1]) {
-          maxPrice0In = swapPrices[1].max_price_0in
-        }
-
-        let minPrice0Out = swapPrices[0].min_price_0out
-        if (minPrice0Out === null && swapPrices[1]) {
-          minPrice0Out = swapPrices[1].min_price_0out
-        }
-
-        let maxPrice0Out = swapPrices[0].max_price_0out
-        if (maxPrice0Out === null && swapPrices[1]) {
-          maxPrice0Out = swapPrices[1].max_price_0out
-        }
+        // min / max token0 input prices are in swapPrices[0]
+        const minPrice0In = swapPrices[0].min_price_0in;
+        const maxPrice0In = swapPrices[0].max_price_0in;
+        // min / max token0 output prices are in swapPrices[1] (which not always exists)
+        const minPrice0Out = swapPrices[1]
+          ? swapPrices[1].min_price_0out
+          : null;
+        const maxPrice0Out = swapPrices[1]
+          ? swapPrices[1].max_price_0out
+          : null;
 
         return {
           pool: swapPrices[0].pool,
@@ -119,7 +110,7 @@ export async function pairLowestHighestSwapPrice(
   } catch (err) {
     console.error(err);
   }
-  return null
+  return null;
 }
 
 /// Query all pair swap volumes from the GraphQL server.

--- a/src/grapqhl/pools.ts
+++ b/src/grapqhl/pools.ts
@@ -103,9 +103,17 @@ export async function pairLowestHighestSwapPrice(
         const decimals1 = tokenInfo.getDecimals(pool.token1);
         if (decimals0 && decimals1) {
           const minPrice =
-            Math.min(swapPrices[0].min_price_0in, swapPrices[1].min_price_0out) * 10 ** (decimals0 - decimals1);
+            Math.min(
+              swapPrices[0].min_price_0in,
+              swapPrices[1].min_price_0out,
+            ) *
+            10 ** (decimals0 - decimals1);
           const maxPrice =
-            Math.max(swapPrices[0].max_price_0in, swapPrices[1].max_price_0out) * 10 ** (decimals0 - decimals1);
+            Math.max(
+              swapPrices[0].max_price_0in,
+              swapPrices[1].max_price_0out,
+            ) *
+            10 ** (decimals0 - decimals1);
           swapPrice = {
             lowestPrice: minPrice,
             highestPrice: maxPrice,

--- a/src/grapqhl/pools.ts
+++ b/src/grapqhl/pools.ts
@@ -87,10 +87,11 @@ export async function pairLowestHighestSwapPrice(
       if (swapPrices.length > 2 || swapPrices.length == 0) {
         console.error(`Expected 1 or 2 swap prices, got ${swapPrices.length}`);
       } else {
-        // min / max token0 input prices are in swapPrices[0]
+        // If swapPrices[1] exists, then input prices are in swapPrices[0], and output prices are in
+        // swapPrices[1]. If swapPrices[1] doesn't exist then all prices must be null, which is also
+        // handled by the logic below. See the corresponding query in common-amm-indexer.
         const minPrice0In = swapPrices[0].min_price_0in;
         const maxPrice0In = swapPrices[0].max_price_0in;
-        // min / max token0 output prices are in swapPrices[1] (which not always exists)
         const minPrice0Out = swapPrices[1]
           ? swapPrices[1].min_price_0out
           : null;

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -105,7 +105,7 @@ export class Pools {
     if (!this.graphqlClient) {
       return null;
     }
-    // We want to query the volumes for the nearest minut.
+    // We want to query the volumes for the nearest minute.
     // This way we can leverage GraphQL caching functionality.
     const fromNearestMinute = (fromMillis / 60000n) * 60000n;
     const toNearestMinute = (toMillis / 60000n) * 60000n;
@@ -126,7 +126,7 @@ export class Pools {
     if (!this.graphqlClient) {
       return null;
     }
-    // We want to query the volumes for the nearest minut.
+    // We want to query the volumes for the nearest minute.
     // This way we can leverage GraphQL caching functionality.
     const fromNearestMinute = (fromMillis / 60000n) * 60000n;
     const toNearestMinute = (toMillis / 60000n) * 60000n;

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -33,7 +33,14 @@ export interface TotalPairSwapVolume {
 export interface LowestHighestSwapPrice {
   pool: string;
   min_price_0in: number | null;
+  min_price_0out: number | null;
   max_price_0in: number | null;
+  max_price_0out: number | null;
+}
+
+export interface TotalLowestHighestSwapPrice {
+  lowestPrice: number | null,
+  highestPrice: number | null,
 }
 
 export interface SwapAmounts {
@@ -94,7 +101,7 @@ export class Pools {
     tokenInfo: TokenInfoById,
     fromMillis: bigint,
     toMillis: bigint,
-  ): Promise<LowestHighestSwapPrice | null> {
+  ): Promise<TotalLowestHighestSwapPrice | null> {
     if (!this.graphqlClient) {
       return null;
     }

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -39,8 +39,8 @@ export interface LowestHighestSwapPrice {
 }
 
 export interface TotalLowestHighestSwapPrice {
-  lowestPrice: number | null,
-  highestPrice: number | null,
+  lowestPrice: number | null;
+  highestPrice: number | null;
 }
 
 export interface SwapAmounts {

--- a/src/models/pool.ts
+++ b/src/models/pool.ts
@@ -101,7 +101,7 @@ export class Pools {
     tokenInfo: TokenInfoById,
     fromMillis: bigint,
     toMillis: bigint,
-  ): Promise<TotalLowestHighestSwapPrice | null> {
+  ): Promise<LowestHighestSwapPrice | null> {
     if (!this.graphqlClient) {
       return null;
     }

--- a/src/services/coingeckoIntegration.ts
+++ b/src/services/coingeckoIntegration.ts
@@ -118,21 +118,21 @@ export class CoingeckoIntegration {
       BigInt(yesterday_millis),
       BigInt(now_millis),
     );
-    if (price !== null && price.min_price_0in !== null && price.max_price_0in !== null && price.min_price_0out !== null && price.max_price_0out !== null) {
+    if (
+      price !== null &&
+      price.min_price_0in !== null &&
+      price.max_price_0in !== null &&
+      price.min_price_0out !== null &&
+      price.max_price_0out !== null
+    ) {
       const decimals0 = tokenInfo.getDecimals(pool.token0);
       const decimals1 = tokenInfo.getDecimals(pool.token1);
       if (decimals0 && decimals1) {
         const minPrice =
-          Math.min(
-            price.min_price_0in,
-            price.min_price_0out,
-          ) *
+          Math.min(price.min_price_0in, price.min_price_0out) *
           10 ** (decimals0 - decimals1);
         const maxPrice =
-          Math.max(
-            price.max_price_0in,
-            price.max_price_0out,
-          ) *
+          Math.max(price.max_price_0in, price.max_price_0out) *
           10 ** (decimals0 - decimals1);
         swapPrice = {
           lowestPrice: minPrice,
@@ -140,7 +140,7 @@ export class CoingeckoIntegration {
         };
       }
     }
-    return swapPrice
+    return swapPrice;
   }
 
   private poolToTicker(

--- a/src/services/coingeckoIntegration.ts
+++ b/src/services/coingeckoIntegration.ts
@@ -121,24 +121,30 @@ export class CoingeckoIntegration {
     const decimals0 = tokenInfo.getDecimals(pool.token0);
     const decimals1 = tokenInfo.getDecimals(pool.token1);
     if (price !== null && decimals0 && decimals1) {
-      let minPrice = price.min_price_0in
-      let maxPrice = price.max_price_0in
+      let minPrice = price.min_price_0in;
+      let maxPrice = price.max_price_0in;
       if (price.min_price_0out !== null) {
-        minPrice = minPrice === null ? price.min_price_0out : Math.min(minPrice, price.min_price_0out)
+        minPrice =
+          minPrice === null
+            ? price.min_price_0out
+            : Math.min(minPrice, price.min_price_0out);
       }
       if (price.max_price_0out !== null) {
-        maxPrice = maxPrice === null ? price.max_price_0out : Math.max(maxPrice, price.max_price_0out)
+        maxPrice =
+          maxPrice === null
+            ? price.max_price_0out
+            : Math.max(maxPrice, price.max_price_0out);
       }
 
       // both are null, or both aren't
       if (minPrice !== null && maxPrice !== null) {
-        minPrice *= 10 ** (decimals0 - decimals1)
-        maxPrice *= 10 ** (decimals0 - decimals1)
+        minPrice *= 10 ** (decimals0 - decimals1);
+        maxPrice *= 10 ** (decimals0 - decimals1);
       }
       swapPrice = {
         lowestPrice: minPrice,
         highestPrice: maxPrice,
-      }
+      };
     }
     return swapPrice;
   }

--- a/src/services/coingeckoIntegration.ts
+++ b/src/services/coingeckoIntegration.ts
@@ -2,6 +2,7 @@ import {
   LowestHighestSwapPrice,
   Pools,
   PoolV2,
+  TotalLowestHighestSwapPrice,
   TotalPairSwapVolume,
 } from "../models/pool";
 import { PairSwapVolume } from "../models/pool";
@@ -104,7 +105,7 @@ export class CoingeckoIntegration {
   private async pairLowestHighestSwapPrice(
     pool: PoolV2,
     tokenInfo: TokenInfoById,
-  ): Promise<LowestHighestSwapPrice> {
+  ): Promise<TotalLowestHighestSwapPrice> {
     let now_millis = new Date().getTime();
     let yesterday_millis = now_millis - DAY_IN_MILLIS;
     const price = await this.pools.poolLowestHighestSwapPrice(
@@ -115,9 +116,8 @@ export class CoingeckoIntegration {
     );
     if (!price) {
       return {
-        pool: pool.id,
-        min_price_0in: null,
-        max_price_0in: null,
+        lowestPrice: null,
+        highestPrice: null,
       };
     } else {
       return price;
@@ -129,7 +129,7 @@ export class CoingeckoIntegration {
     poolVolume: TotalPairSwapVolume,
     lastPrice: number | null,
     liquidityInUsd: number,
-    lowestHighest: LowestHighestSwapPrice,
+    lowestHighest: TotalLowestHighestSwapPrice,
   ): Ticker {
     return {
       ticker_id: `${pool.token0}_${pool.token1}`,
@@ -141,12 +141,12 @@ export class CoingeckoIntegration {
       target_volume: poolVolume.token1Volume.toString(),
       liquidity_in_usd: liquidityInUsd.toString(),
       high:
-        lowestHighest.max_price_0in !== null
-          ? lowestHighest.max_price_0in.toString()
+        lowestHighest.highestPrice !== null
+          ? lowestHighest.highestPrice.toString()
           : null,
       low:
-        lowestHighest.min_price_0in !== null
-          ? lowestHighest.min_price_0in.toString()
+        lowestHighest.lowestPrice !== null
+          ? lowestHighest.lowestPrice.toString()
           : null,
     };
   }

--- a/src/services/coingeckoIntegration.ts
+++ b/src/services/coingeckoIntegration.ts
@@ -118,26 +118,26 @@ export class CoingeckoIntegration {
       BigInt(yesterday_millis),
       BigInt(now_millis),
     );
-    if (
-      price !== null &&
-      price.min_price_0in !== null &&
-      price.max_price_0in !== null &&
-      price.min_price_0out !== null &&
-      price.max_price_0out !== null
-    ) {
-      const decimals0 = tokenInfo.getDecimals(pool.token0);
-      const decimals1 = tokenInfo.getDecimals(pool.token1);
-      if (decimals0 && decimals1) {
-        const minPrice =
-          Math.min(price.min_price_0in, price.min_price_0out) *
-          10 ** (decimals0 - decimals1);
-        const maxPrice =
-          Math.max(price.max_price_0in, price.max_price_0out) *
-          10 ** (decimals0 - decimals1);
-        swapPrice = {
-          lowestPrice: minPrice,
-          highestPrice: maxPrice,
-        };
+    const decimals0 = tokenInfo.getDecimals(pool.token0);
+    const decimals1 = tokenInfo.getDecimals(pool.token1);
+    if (price !== null && decimals0 && decimals1) {
+      let minPrice = price.min_price_0in
+      let maxPrice = price.max_price_0in
+      if (price.min_price_0out !== null) {
+        minPrice = minPrice === null ? price.min_price_0out : Math.min(minPrice, price.min_price_0out)
+      }
+      if (price.max_price_0out !== null) {
+        maxPrice = maxPrice === null ? price.max_price_0out : Math.max(maxPrice, price.max_price_0out)
+      }
+
+      // both are null, or both aren't
+      if (minPrice !== null && maxPrice !== null) {
+        minPrice *= 10 ** (decimals0 - decimals1)
+        maxPrice *= 10 ** (decimals0 - decimals1)
+      }
+      swapPrice = {
+        lowestPrice: minPrice,
+        highestPrice: maxPrice,
       }
     }
     return swapPrice;


### PR DESCRIPTION
## Description

If `lowest` and `highest` prices exist for last 24h then `last_price` must be contained in `[lowest, highest]` which wasn't the case. Turns out we were only considering trades in direction `base -> target` when computing `lowest, highest` so not all necessary data was considered. This PR makes it so trades in both directions are considered, and consequently `last_price` always lies inside `[lowest, highest]` (if they exist).

## Testing

```
[
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5C6s2qJAG5dCmPvR9WyKAVL6vJRDS9BjMwbrqwXGCsPiFViF",
    "last_price": "0.4737735627128397",
    "base_volume": "217382.73816385888",
    "target_volume": "105967.786144",
    "liquidity_in_usd": "1556305.9156352398",
    "high": "0.5072231197383308",
    "low": "0.4644436524031197"
  },
  {
    "ticker_id": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5CiP96MhEGHnLFGS64uVznrwbuVdFj6kewrEZoLRzxUEqxws",
    "last_price": "1.0085995504748813",
    "base_volume": "7485.541567",
    "target_volume": "7571.624193",
    "liquidity_in_usd": "1014995.6794759999",
    "high": "1.0185838995465697",
    "low": "1.0085995504748813"
  },
  {
    "ticker_id": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5D4DxNZMLG4Cff9G7rywJR2HPwu3D9zgeKHwLFh1xNjTBQ1K",
    "last_price": "2873.5000574879687",
    "base_volume": "0.001659134937962616",
    "target_volume": "4.897585",
    "liquidity_in_usd": "169.34782931775067",
    "high": "2968.0475900162387",
    "low": "2873.500057487969"
  },
  {
    "ticker_id": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE_5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "base_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "target_currency": "5FYFojNCJVFR2bBNKfAePZCa72ZcVX5yeTv8K9bzeUo8D83Z",
    "pool_id": "5DJkepNcfcm1S1KNDELMUNJDGQ1wgDuHY5457ac3kbmjGakA",
    "last_price": "1.2988209458822642",
    "base_volume": "0",
    "target_volume": "0",
    "liquidity_in_usd": "2.001689",
    "high": null,
    "low": null
  },
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "pool_id": "5DVQsLtAEKgwpd1k1dkcKbuQ4UBkYUTKW2dTMVXXNywUsFcZ",
    "last_price": "0.46600450255730913",
    "base_volume": "16.624199220987",
    "target_volume": "8.066648",
    "liquidity_in_usd": "248.57014745757112",
    "high": "0.50579647702753",
    "low": "0.4660045025573092"
  },
  {
    "ticker_id": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u_5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "base_currency": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "target_currency": "5Et3dDcXUiThrBCot7g65k3oDSicGy4qC82cq9f911izKNtE",
    "pool_id": "5Gr7hs43AZdG5MygDG6LU9ADcw5QtgpULELrZQHKi8sDHNgs",
    "last_price": "2908.022760260988",
    "base_volume": "0.000997245110735842",
    "target_volume": "3.016199",
    "liquidity_in_usd": "109.3758812490838",
    "high": null,
    "low": null
  },
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5EoFQd36196Duo6fPTz2MWHXRzwTJcyETHyCyaB3rb61Xo2u",
    "pool_id": "5HaM6dHg3ymuQ6NSCquMkzBLLHv9t1H4YvBDMarox37PbusE",
    "last_price": "0.00016478634896464786",
    "base_volume": "7227.377604230133",
    "target_volume": "1.190789149277148",
    "liquidity_in_usd": "921159.4153552596",
    "high": "0.00016556602678277917",
    "low": "0.00016373395706176762"
  },
  {
    "ticker_id": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg_5EEtCdKLyyhQnNQWWWPM1fMDx1WdVuiaoR9cA6CWttgyxtuJ",
    "base_currency": "5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg",
    "target_currency": "5EEtCdKLyyhQnNQWWWPM1fMDx1WdVuiaoR9cA6CWttgyxtuJ",
    "pool_id": "5HNe42pTtcpGYsE3hPy6NKuV8mmKcN7Tz9SBUsSgxTDrWQmh",
    "last_price": "0.00000729",
    "base_volume": "0",
    "target_volume": "0",
    "liquidity_in_usd": "0.0005747787571758641",
    "high": null,
    "low": null
  }
]
```