### PR TITLE
Increase pool limit in subscription

### DIFF
--- a/src/grapqhl/v2/queries.ts
+++ b/src/grapqhl/v2/queries.ts
@@ -25,7 +25,7 @@ export const poolsV2SubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "pools",
     "id token0 token1 reserves0 reserves1 blockTimestamp",
-    60,
+    200,
     "blockTimestamp_ASC",
   );
 

--- a/src/grapqhl/v2/queries.ts
+++ b/src/grapqhl/v2/queries.ts
@@ -25,7 +25,7 @@ export const poolsV2SubscriptionQuery: SubscriptionQuery =
   new SubscriptionQuery(
     "pools",
     "id token0 token1 reserves0 reserves1 blockTimestamp",
-    50,
+    60,
     "blockTimestamp_ASC",
   );
 


### PR DESCRIPTION
On testnet, we have 54 pools currently indexed, and this causes the remaining 4 pools not being updated. I'm increasing the limit a bit. The default for subscription query is left as it was (50).